### PR TITLE
fix: input file drag and drop safari

### DIFF
--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -217,13 +217,7 @@ const InputFile = React.forwardRef<HTMLInputElement, InputFileProps>(
 			select(dataTransfer);
 		};
 
-		const onDragEnter = (
-			event: DragEvent | React.DragEvent<HTMLDivElement>,
-		) => {
-			if (!event.dataTransfer.items.length) {
-				return;
-			}
-
+		const onDragEnter = () => {
 			setShowBackdrop(true);
 		};
 		const onDragOver = (


### PR DESCRIPTION
- on safari `event.dataTransfer.items.length` is 0
- on chrome it is not